### PR TITLE
Fix artifacts when using color restoration

### DIFF
--- a/src/gradio_s3diff.py
+++ b/src/gradio_s3diff.py
@@ -86,7 +86,8 @@ def process(
         im_lr,
         size=(int(ori_h * scale_factor),
               int(ori_w * scale_factor)),
-        mode='bicubic',
+        mode='bilinear',
+        align_corners=True
         )
     im_lr_resize = im_lr_resize.contiguous() 
     im_lr_resize_norm = im_lr_resize * 2 - 1.0

--- a/src/inference_s3diff.py
+++ b/src/inference_s3diff.py
@@ -179,7 +179,8 @@ def main(args):
             im_lr,
             size=(ori_h * config.sf,
                   ori_w * config.sf),
-            mode='bicubic',
+            mode='bilinear',
+            align_corners=True
             )
 
         im_lr_resize = im_lr_resize.contiguous() 


### PR DESCRIPTION
Bicubic can result in values above 1.0, which result in an image with invalid colors when converted to a PIL image, as per documentation it has to be clamped, or we can just use bilinear, as it shouldn't matter for this anyway.

Not that you shouldn't use PIL images anyway as it costs some precision due to PIL images being 8 bits, you can skip the conversion to a PIL image entirely by using the adaptive_instance_normalization and wavelet_reconstruction functions with tensors directly.

Also, align_corners turned on for good measure, as it's generally a good idea.