### PR TITLE
Disable align_corners

### DIFF
--- a/src/gradio_s3diff.py
+++ b/src/gradio_s3diff.py
@@ -87,7 +87,7 @@ def process(
         size=(int(ori_h * scale_factor),
               int(ori_w * scale_factor)),
         mode='bilinear',
-        align_corners=True
+        align_corners=False # align_corners with this model causes the output to be shifted, presumably due to training without align_corners
         )
     im_lr_resize = im_lr_resize.contiguous() 
     im_lr_resize_norm = im_lr_resize * 2 - 1.0

--- a/src/inference_s3diff.py
+++ b/src/inference_s3diff.py
@@ -180,7 +180,7 @@ def main(args):
             size=(ori_h * config.sf,
                   ori_w * config.sf),
             mode='bilinear',
-            align_corners=True
+            align_corners=False # align_corners with this model causes the output to be shifted, presumably due to training without align_corners
             )
 
         im_lr_resize = im_lr_resize.contiguous() 


### PR DESCRIPTION
Turns out that align_corners causes corners to be misaligned with this model, presumably due to align_corners being disabled during training.

align_corners should have been turned on during training too, but it's far too late to change that now.

I should have checked this before making the previous pull request that turned it on.